### PR TITLE
Upgrade xml test package; relax package requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ astunparse
 bs4
 keyring
 pyCOMPS~=2.6
-requests==2.29.0
-xmlrunner~=1.7.7
-pytest==8.1.2
+requests~=2.29
+unittest-xml-reporting~=3.2
+pytest~=8.1


### PR DESCRIPTION
Addresses #3

Also relaxes package requirements for requests and pytest. Should usually avoid pinning requirements to a specific patch unless something is super crunchy.